### PR TITLE
fix: class didn't covered

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,13 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+無論如何都會編譯，
+權重大於 base、components、utilities
+*/
+.rdrDateDisplayWrapper{
+  background-color: red;
+}
 
 @layer components{
   /*這行無效*/
-  .rdrDateDisplayWrapper{
+  /* .rdrDateDisplayWrapper{
     background-color: red;
-  }
-
+  } */
+  
   .tailwindTest{
     color: aqua;
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
+    "./node_modules/react-date-range/dist/theme/default.css",
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
以下修改的兩個檔案分別是兩個方法，
擇一即可。

個人比較推薦將要覆蓋用的自定義 class 挪到 layer 之外，
使 tailwind 強制編譯它

在 layer 內的會受到 tree-shake 的影響不再重新編譯，
但這是 tailwind 本身，還是打包機制而導致的，
我還沒搞清楚，但我會去問作者～